### PR TITLE
[#1] Add wandb setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,5 +170,6 @@ Thumbs.db
 
 #log
 log/
+wandb/
 .vscode/
 

--- a/configs/Attention.yaml
+++ b/configs/Attention.yaml
@@ -50,3 +50,7 @@ optimizer:
   lr: 5e-4 # 1e-4
   weight_decay: 1e-4
   is_cycle: True
+
+wandb:
+  wandb: True
+  run_name: ""

--- a/configs/SATRN.yaml
+++ b/configs/SATRN.yaml
@@ -50,3 +50,7 @@ optimizer:
   lr: 5e-4 # 1e-4
   weight_decay: 1e-4
   is_cycle: True
+
+wandb:
+  wandb: True
+  run_name: ""

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ torchvision==0.2.1
 Pillow==8.1.1
 tensorboardX==1.5
 editdistance==0.5.3
+python-dotenv==0.17.1
+wandb=0.10.30

--- a/utils.py
+++ b/utils.py
@@ -1,4 +1,5 @@
 import yaml
+from copy import deepcopy
 import torch.optim as optim
 
 from networks.Attention import Attention

--- a/utils.py
+++ b/utils.py
@@ -33,3 +33,37 @@ def get_optimizer(optimizer, params, lr, weight_decay=None):
     else:
         raise NotImplementedError
     return optimizer
+
+
+def get_wandb_config(config_file):
+    # load config file
+    with open(config_file, 'r') as f:
+        option = yaml.safe_load(f)
+    config = deepcopy(option)
+
+    # remove all except network
+    keys = ["checkpoint", "input_size", "data", "optimizer", "wandb", "prefix"]
+    for key in keys:
+        del config[key]
+
+    # modify some config key-value
+    new_config = {
+        "log_path": option['prefix'],
+        "dataset_proportions": option['data']['dataset_proportions'],
+        "test_proportions": option['data']['test_proportions'],
+        "crop": option['data']['crop'],
+        "rgb": "grayscale" if option['data']['rgb']==1 else "color",
+        "input_size": (option['input_size']['height'], option['input_size']['width']),
+        "optimizer": option['optimizer']['optimizer'],
+        "learning_rate": option['optimizer']['lr'],
+        "weight_decay": option['optimizer']['weight_decay'],
+        "is_cycle": option['optimizer']['is_cycle'],
+    }
+
+    # merge
+    config.update(new_config)
+
+    # print log
+    print("wandb save configs below:\n", list(config.keys()))
+
+    return config 

--- a/utils.py
+++ b/utils.py
@@ -1,3 +1,4 @@
+import yaml
 import torch.optim as optim
 
 from networks.Attention import Attention


### PR DESCRIPTION
## ✨ Types of Changes

- [ ] Bugfix
- [x] New Feature
- [x] Documentation

## ✅ Checklist

- [x] Enough documentation in Pull Request or README.md
- [x] Add comments to explain code
- [x] Observe python PEP8 rule
- [x] Check if code works well

## 📝 Proposed Changes

### 추가된 코드
- config를 wandb에 저장하기 좋도록 파싱하는 코드가 `utils.py`에 추가되었습니다.
- dotenv를 사용해 각자의 wandb project와 entity를 가져와 wandb project setting을 할 수 있도록 했습니다.
- checkpoint 저장 시 lr이 저장이 안 되는 버그를 수정했습니다.
- wandb와 dotenv 사용을 위해 requirements.txt에 해당 패키지를 추가했습니다.

### 사용법

#### wandb와 dotenv 설치
- requirements.txt 설치
```shell
pip install -r requirements.txt
```
- conda를 사용한 설치
```shell
conda install -c conda-forge python-dotenv wandb
```

#### root 디렉토리에 `.env` 파일 생성 및 환경 변수 저장

```
PROJECT="[wandb 프로젝트 명]"
ENTITY="[wandb 유저명]"
```

#### config 파일에 wandb 사용여부 작성

현재 모든 모델 config에 wandb key-value를 추가했습니다.
- `wandb.wandb`: wandb 사용 여부 (False면 사용하지 않음)
- `wandb.run_name`: 실행 시 프로젝트에 기록될 run name
   - ""로 놔두면 wandb에서 임의로 이름을 붙입니다.
   - "[이름]"으로 설정하면 wandb에 해당 이름으로 run이 생성됩니다. 기존에 같은 이름의 run이 있더라도 덮어씌워지지 않습니다.

```yaml
...
optimizer:
  optimizer: 'Adam' # Adam, Adadelta
  lr: 5e-4 # 1e-4
  weight_decay: 1e-4
  is_cycle: True

wandb
  wandb: True
  run_name: ""
```